### PR TITLE
Rebuild for x86_64-apple-darwin20.0.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - rafaelmartins-qt
+
+upload_without_merge: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 673ab783a1b14613abc58dca5bf3fcb05f0ddabd35c587c949661f8c499b8523
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win or (linux and s390x)]
 
 requirements:
@@ -31,17 +31,17 @@ test:
     - test -f $PREFIX/include/tapi/tapi.h
 
 about:
-  home: https://opensource.apple.com/source/tapi
+  home: https://github.com/tpoechtrager/apple-libtapi
   license: NCSA
   license_family: MIT
   license_file:
     - LICENSE.APPLE-LIBTAPI.txt
     - LICENSE.LLVM.txt
-  summary: 'TAPI is a Text-based Application Programming Interface'
-  doc_url: https://opensource.apple.com/source/tapi/tapi-{{ version }}/Readme.md
-  dev_url: https://github.com/ributzka/tapi
+  summary: TAPI is a Text-based Application Programming Interface
+  description: TAPI is a Text-based Application Programming Interface
+  doc_url: https://github.com/tpoechtrager/apple-libtapi
+  dev_url: https://github.com/tpoechtrager/apple-libtapi
 
 extra:
-  recipe-maintainers:
-    - isuruf
-    - katietz
+  skip-lints:
+    - host_section_needs_exact_pinnings


### PR DESCRIPTION
tapi 1100.0.11

**Destination channel:** defaults

### Links

- [PKG-5177](https://anaconda.atlassian.net/browse/PKG-5177) 
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/pull/4

### Explanation of changes:

- We need this for qt 6.7 in macos intel machines. The existing tapi version is incompatible with qt 6.7 (we currently use tapi 1000 for intel machines, this rebuild is needed so we can use the newer tapi, that was already available for arm64 machines).


[PKG-5177]: https://anaconda.atlassian.net/browse/PKG-5177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ