### PR TITLE
Revert "Merge pull request #3 from AnacondaRecipes/new-clang_bootstrap" skip CI

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - rafaelmartins-qt
-
-upload_without_merge: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 673ab783a1b14613abc58dca5bf3fcb05f0ddabd35c587c949661f8c499b8523
 
 build:
-  number: 2
+  number: 1
   skip: True  # [win or (linux and s390x)]
 
 requirements:
@@ -31,17 +31,17 @@ test:
     - test -f $PREFIX/include/tapi/tapi.h
 
 about:
-  home: https://github.com/tpoechtrager/apple-libtapi
+  home: https://opensource.apple.com/source/tapi
   license: NCSA
   license_family: MIT
   license_file:
     - LICENSE.APPLE-LIBTAPI.txt
     - LICENSE.LLVM.txt
-  summary: TAPI is a Text-based Application Programming Interface
-  description: TAPI is a Text-based Application Programming Interface
-  doc_url: https://github.com/tpoechtrager/apple-libtapi
-  dev_url: https://github.com/tpoechtrager/apple-libtapi
+  summary: 'TAPI is a Text-based Application Programming Interface'
+  doc_url: https://opensource.apple.com/source/tapi/tapi-{{ version }}/Readme.md
+  dev_url: https://github.com/ributzka/tapi
 
 extra:
-  skip-lints:
-    - host_section_needs_exact_pinnings
+  recipe-maintainers:
+    - isuruf
+    - katietz


### PR DESCRIPTION
This reverts commit 1a0f4a91d03bdf95347e2552daeb222716e895f8, reversing changes made to 079511deef86a02b77a797fdcec8b077e1e98b68.

This version was pulled from defaults due to issues it introduced to do with compiling python packages with c extensions on osx-64 for py <=3.9.